### PR TITLE
Change titlenode font size from 60 to 40 in BalanceGameView.js

### DIFF
--- a/js/game/view/BalanceGameView.js
+++ b/js/game/view/BalanceGameView.js
@@ -184,7 +184,7 @@ define( function( require ) {
     // the appropriate state change.
     thisScreen.challengeTitleNode = new Text( '',
       {
-        font: new PhetFont( { size: 60, weight: 'bold' } ),
+        font: new PhetFont( { size: 40, weight: 'bold' } ),
         fill: 'white',
         stroke: 'black',
         lineWidth: 1.5,


### PR DESCRIPTION
In challengeTitleNode: the font size 60 is very big for use some translated strings, like pt_BR. The string is over the side panel. I tested it with size: 40.
